### PR TITLE
Fixing an issue in the visu function.

### DIFF
--- a/nfa.py
+++ b/nfa.py
@@ -21,7 +21,7 @@
 
 from toolkit import *
 from collections import defaultdict
-
+import html
 
 # TODO: meta decorator to choose what to preserve, using setattr
 def preserve(m):
@@ -1105,7 +1105,9 @@ class NFA:
         lang = NFA.VISULANG if lang is None else lang
         if lang:
             L = list(original[:lang+1])
-            comment += "<br/><br/>" + sortstr(L[:lang]) + ("+" if len(L)>lang else "")
+            comment_append = sortstr(L[:lang]) + ("+" if len(L)>lang else "")
+            comment_append = html.escape(comment_append)
+            comment+= f"<br/><br/>{comment_append}"
 
         if comment and not nocomment: dotc += """
             label=<%s>;


### PR DESCRIPTION
If there is html special character such as '<' or '>' in the character for the transitions, the list of the first words recognized in the comment variable will create an invalid file format for the visu.dot file and cause an exception. 
Fixing it using the escape function from the html lib.